### PR TITLE
POCO_UID & POCO_GID as env variables

### DIFF
--- a/poco/poco.py
+++ b/poco/poco.py
@@ -40,6 +40,7 @@ class Poco(object):
     def __init__(self, home_dir=os.path.join(os.path.expanduser(path='~'), '.poco'),
                  argv=sys.argv[1:]):
         EnvironmentUtils.check_version(__version__)
+        EnvironmentUtils.set_poco_uid_and_gid()
 
         StateHolder.home_dir = home_dir
         self.argv = argv

--- a/poco/services/environment_utils.py
+++ b/poco/services/environment_utils.py
@@ -11,6 +11,16 @@ class EnvironmentUtils:
         return os.environ.get(key, default)
 
     @staticmethod
+    def set_variable(key, value):
+        os.environ[key] = value
+
+    @staticmethod
+    def set_poco_uid_and_gid():
+        if os.name == "posix":
+            EnvironmentUtils.set_variable("POCO_UID", str(os.getuid()))
+            EnvironmentUtils.set_variable("POCO_GID", str(os.getgid()))
+
+    @staticmethod
     def check_docker():
         p = Popen("docker version -f {{.Server.Version}}", stdout=PIPE, stderr=PIPE, shell=True)
         out, err = p.communicate()


### PR DESCRIPTION
Add the POCO runner user's uid and gid as environment variables, so they can be injected into a container

Reason: on posix hostmachines, sometimes we want to use different user than root inside a container, because for example the files generated by a root process in a container also have root privileges.
These env variables make it possible to create a user in the container with the same uid and gid as the user who gave the poco command on the hostmachine.