### PR TITLE
Specify yaml loader

### DIFF
--- a/poco/services/abstract_repository.py
+++ b/poco/services/abstract_repository.py
@@ -27,7 +27,7 @@ class AbstractRepository(object):
                 FileUtils.make_empty_file_with_empty_dict(directory=self.target_dir, file=file)
             else:
                 return None
-        return YamlUtils.read(result, fault_tolerant=True)
+        return YamlUtils.read(result)
 
     def write_yaml_file(self, file, content, overwrite=True, create=False):
         result = self.get_file(file)

--- a/poco/services/abstract_repository.py
+++ b/poco/services/abstract_repository.py
@@ -4,6 +4,7 @@ import sys
 import platform
 from .console_logger import ColorPrint
 from .file_utils import FileUtils
+from .yaml_utils import YamlUtils
 from subprocess import Popen, PIPE
 if sys.version_info[0] < 3:
     import urlparse
@@ -27,12 +28,7 @@ class AbstractRepository(object):
                 FileUtils.make_empty_file_with_empty_dict(directory=self.target_dir, file=file)
             else:
                 return None
-        try:
-            with open(result) as stream:
-                return yaml.load(stream)
-        except yaml.YAMLError as exc:
-            ColorPrint.exit_after_print_messages(
-                message="Error: Wrong YAML format:\n " + str(exc), msg_type="warn")
+        return YamlUtils.read(result, fault_tolerant=True)
 
     def write_yaml_file(self, file, content, overwrite=True, create=False):
         result = self.get_file(file)

--- a/poco/services/abstract_repository.py
+++ b/poco/services/abstract_repository.py
@@ -1,5 +1,4 @@
 import os
-import yaml
 import sys
 import platform
 from .console_logger import ColorPrint

--- a/poco/services/command_handler.py
+++ b/poco/services/command_handler.py
@@ -1,5 +1,4 @@
 import os
-import yaml
 import platform
 from .console_logger import ColorPrint, Doc
 from .file_utils import FileUtils

--- a/poco/services/command_handler.py
+++ b/poco/services/command_handler.py
@@ -8,6 +8,7 @@ from .environment_utils import EnvironmentUtils
 from .package_handler import PackageHandler
 from .state import StateHolder
 from .command_runners import ScriptPlanRunner, DockerPlanRunner, KubernetesRunner, HelmRunner
+from .yaml_utils import YamlUtils
 
 
 class CommandHandler(object):
@@ -39,12 +40,8 @@ class CommandHandler(object):
 
     @staticmethod
     def load_hierarchy():
-        with open(os.path.join(os.path.dirname(__file__), 'resources/command-hierarchy.yml')) as stream:
-            try:
-                return yaml.load(stream=stream)
-            except yaml.YAMLError as exc:
-                ColorPrint.exit_after_print_messages(message="Error: Wrong YAML format:\n " + str(exc),
-                                                     doc=Doc.POCO)
+        return YamlUtils.read(os.path.join(os.path.dirname(__file__), 'resources/command-hierarchy.yml'),
+                              doc=Doc.POCO, fault_tolerant=True)
 
     def run_script(self, script):
         self.script_runner.run(plan=self.project_compose['plan'][self.plan], script_type=script)

--- a/poco/services/command_handler.py
+++ b/poco/services/command_handler.py
@@ -40,7 +40,7 @@ class CommandHandler(object):
     @staticmethod
     def load_hierarchy():
         return YamlUtils.read(os.path.join(os.path.dirname(__file__), 'resources/command-hierarchy.yml'),
-                              doc=Doc.POCO, fault_tolerant=True)
+                              doc=Doc.POCO)
 
     def run_script(self, script):
         self.script_runner.run(plan=self.project_compose['plan'][self.plan], script_type=script)

--- a/poco/services/compose_handler.py
+++ b/poco/services/compose_handler.py
@@ -30,7 +30,7 @@ class ComposeHandler:
             return
         with open(self.compose_file) as stream:
             try:
-                self.compose_project = YamlUtils.ordered_load(stream, yaml.SafeLoader)
+                self.compose_project = YamlUtils.ordered_load(stream)
 
                 if 'plan' not in self.compose_project:
                     ColorPrint.exit_after_print_messages(

--- a/poco/services/git_repository.py
+++ b/poco/services/git_repository.py
@@ -150,5 +150,9 @@ class GitRepository(AbstractRepository):
 class Progress(git.remote.RemoteProgress):
 
     def update(self, op_code, cur_count, max_count=None, message=''):
-        print(self._cur_line, end='\r')
-        sys.stdout.flush()
+        is_end = op_code & git.RemoteProgress.END != 0
+        if is_end:
+            print(self._cur_line)
+        else:
+            print(self._cur_line, end='\r')
+            sys.stdout.flush()

--- a/poco/services/git_repository.py
+++ b/poco/services/git_repository.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+import sys
 import os
 import git
 import shutil
@@ -149,4 +149,5 @@ class GitRepository(AbstractRepository):
 class Progress(git.remote.RemoteProgress):
 
     def update(self, op_code, cur_count, max_count=None, message=''):
-        print(self._cur_line, end="\r")
+        print(self._cur_line + '\r')
+        sys.stdout.flush()

--- a/poco/services/git_repository.py
+++ b/poco/services/git_repository.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import sys
 import os
 import git
@@ -149,5 +150,5 @@ class GitRepository(AbstractRepository):
 class Progress(git.remote.RemoteProgress):
 
     def update(self, op_code, cur_count, max_count=None, message=''):
-        print(self._cur_line + '\r')
+        print(self._cur_line, end='\r')
         sys.stdout.flush()

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup_options = dict(
       'console_scripts': ['poco=poco.poco:main'],
     },
     license="Apache License 2.0",
-    classifiers=(
+    classifiers=[
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',
         'Intended Audience :: System Administrators',
@@ -66,7 +66,7 @@ setup_options = dict(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
-    ),
+    ],
 )
 
 setup(**setup_options)


### PR DESCRIPTION
yaml.load produced a bunch of deprecation warnings, because the default loader in previous versions is unsafe
a specific loader must be provided to the function