### PR TITLE
before and after script support custom image and command array

### DIFF
--- a/poco/services/command_runners.py
+++ b/poco/services/command_runners.py
@@ -64,10 +64,9 @@ class ScriptPlanRunner(AbstractPlanRunner):
         return base_image
 
     def get_script_command(self, script):
+        command = script
         if isinstance(script, dict) and 'command' in script:
             command = script['command']
-        else:
-            command = script
         return self.get_script_command_array(command)
 
     def get_script_command_array(self, command):

--- a/poco/tests/poco_test.py
+++ b/poco/tests/poco_test.py
@@ -466,17 +466,6 @@ class PocoTestSuite(AbstractTestSuite):
         self.assertEqual(0, len(err.getvalue().strip()))
         self.assertTrue(os.path.exists(directory))
 
-    def test_install_with_before_script(self):
-        self.init_with_remote_catalog()
-        base_dir = os.path.join(self.ws_dir, 'poco-example')
-        dir = os.path.join(base_dir, 'nginx')
-        self.assertFalse(os.path.exists(dir))
-        with self.captured_output() as (out, err):
-            self.run_poco_command("install", "nginx")
-        self.assertIn("Install completed to " + base_dir, out.getvalue().strip())
-        self.assertEqual(0, len(err.getvalue().strip()))
-        self.assertTrue(os.path.exists(dir))
-
     def test_plan_list_with_not_exists_project(self):
         self.init_with_local_catalog()
         with self.captured_output() as (out, err):


### PR DESCRIPTION
The script step support backward compatibility command (like "ls -la") and support new command structure (name of image and list of commands)

`before_script:
  - command: ls -la
    image: alpine
  - command: ['sh', '-c', 'echo The app is running!']
  - command: 
    - sh
    - '-c'
    - "echo The app is running!"
  - ls -la
`