### PR TITLE
added GID and UID from env to docker compose system call

### DIFF
--- a/poco/services/command_runners.py
+++ b/poco/services/command_runners.py
@@ -12,6 +12,8 @@ class AbstractPlanRunner(object):
 
     @staticmethod
     def run_script_with_check(cmd, working_directory, envs):
+        envs['GID']=os.environ.get('GID', '')
+        envs['UID']=os.environ.get('UID', '')
         res = check_call(" ".join(cmd), cwd=working_directory, env=envs, shell=True)
         if res > 0:
             ColorPrint.exit_after_print_messages(message=res)


### PR DESCRIPTION
Poco won't propagate the exported GID and UID env vars to the started docker compose process makes it impossible to mount a volume using the defined user by GID and UID.

Other arbitrary export environmental variables gets exported to the process except for the GID and UID. Those variables mysteriously during poco up.

This is a quick workaround to add them back again.